### PR TITLE
Fix night kill not resetting status

### DIFF
--- a/app/game/[id]/play/page.tsx
+++ b/app/game/[id]/play/page.tsx
@@ -278,6 +278,7 @@ export default function GameDashboard({ params }: { params: { id: string } }) {
                 onPhaseComplete={togglePhase}
                 onResetTimer={resetTimer}
                 onTogglePhase={togglePhase}
+                onCheckWinCondition={checkWinCondition}
               />
             ) : (
               <DayPhasePanel

--- a/components/night-wizard.tsx
+++ b/components/night-wizard.tsx
@@ -29,6 +29,7 @@ interface NightWizardProps {
   onPhaseComplete: () => void
   onResetTimer: (seconds: number) => void
   onTogglePhase: () => void
+  onCheckWinCondition?: () => void
 }
 
 const steps: { id: NightStep; title: string; description: string; icon: string }[] = [
@@ -47,6 +48,7 @@ export function NightWizard({
   onPhaseComplete,
   onResetTimer,
   onTogglePhase,
+  onCheckWinCondition,
 }: NightWizardProps) {
   const [selectedTarget, setSelectedTarget] = useState<string | null>(null)
   const [nightActions, setNightActions] = useState<Record<string, string>>({})
@@ -83,11 +85,18 @@ export function NightWizard({
 
     // Only kill if not healed by doctor
     if (killedPlayerId && killedPlayerId !== healedPlayerId) {
-      setPlayers(players.map((p) => (p.id === killedPlayerId ? { ...p, isAlive: false } : p)))
+      setPlayers(
+        players.map((p) =>
+          p.id === killedPlayerId
+            ? { ...p, isAlive: false, isNominated: false, isSpeaking: false, votes: 0 }
+            : p,
+        ),
+      )
     }
 
     // Reset for next night
     setNightActions({})
+    onCheckWinCondition?.()
     onPhaseComplete()
   }
 


### PR DESCRIPTION
## Summary
- reset status flags when eliminating a player via night actions
- call win check after night resolution
- wire check callback from `GameDashboard` to `NightWizard`

## Testing
- `npx tsc -p tsconfig.json` *(fails: Cannot find module '@radix-ui/react-toggle' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_683f534cc44083238ee963338291eb8d