### PR TITLE
Fix reshuffle crash when adding players

### DIFF
--- a/app/game/[id]/play/page.tsx
+++ b/app/game/[id]/play/page.tsx
@@ -84,6 +84,18 @@ export default function GameDashboard({ params }: { params: { id: string } }) {
       }
     })
 
+    // If more players than roles (e.g. players added mid-game),
+    // pad the role array with default "Citizen" roles
+    const citizenRole =
+      gameConfig.roles.find((r: any) => r.name.toLowerCase() === "citizen") ?? {
+        name: "Citizen",
+        color: "bg-yellow-600 text-black",
+        faction: "city",
+      }
+    while (players.length > roleArray.length) {
+      roleArray.push(citizenRole.name)
+    }
+
     // Shuffle roles
     const shuffledRoles = [...roleArray].sort(() => Math.random() - 0.5)
 

--- a/components/player-card.tsx
+++ b/components/player-card.tsx
@@ -45,12 +45,14 @@ export function PlayerCard({
   totalVotesUsed,
   totalAlivePlayers,
 }: PlayerCardProps) {
-  const getRoleClass = (role: string) => {
-    if (role.toLowerCase().includes("don")) return "role-don text-white"
-    if (role.toLowerCase().includes("mafia")) return "role-mafia text-white"
-    if (role.toLowerCase().includes("detective")) return "role-detective text-white"
-    if (role.toLowerCase().includes("doctor")) return "role-doctor text-white"
-    if (role.toLowerCase().includes("citizen")) return "role-citizen text-black"
+  const getRoleClass = (role: string | undefined) => {
+    if (!role) return "bg-gray-600 text-white"
+    const lower = role.toLowerCase()
+    if (lower.includes("don")) return "role-don text-white"
+    if (lower.includes("mafia")) return "role-mafia text-white"
+    if (lower.includes("detective")) return "role-detective text-white"
+    if (lower.includes("doctor")) return "role-doctor text-white"
+    if (lower.includes("citizen")) return "role-citizen text-black"
     return "bg-gray-600 text-white"
   }
 


### PR DESCRIPTION
## Summary
- handle extra players in `reshuffleRoles`
- guard `getRoleClass` against undefined role values

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683f58a7018c8323b092ea3b6ba3e156