### PR TITLE
Improve game controls and role management

### DIFF
--- a/app/game/[id]/lobby/page.tsx
+++ b/app/game/[id]/lobby/page.tsx
@@ -5,7 +5,13 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Textarea } from "@/components/ui/textarea"
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { PlayerList } from "@/components/player-list"
 import { RoleConfigurator } from "@/components/role-configurator"
@@ -29,23 +35,29 @@ interface Role {
   isCustom?: boolean
 }
 
-const defaultRoles: Role[] = [
-  { id: "don", name: "Don Mafia", faction: "mafia", color: "bg-black text-white", count: 1 },
-  { id: "mafia", name: "Mafia", faction: "mafia", color: "bg-red-600 text-white", count: 2 },
-  { id: "detective", name: "Detective", faction: "city", color: "bg-blue-600 text-white", count: 1 },
-  { id: "doctor", name: "Doctor", faction: "city", color: "bg-green-600 text-white", count: 1 },
-  { id: "citizen", name: "Citizen", faction: "city", color: "bg-yellow-600 text-black", count: 3 },
+const roleTemplates = [
+  { id: "don", name: "Don Mafia", faction: "mafia", color: "bg-black text-white" },
+  { id: "mafia", name: "Mafia", faction: "mafia", color: "bg-red-600 text-white" },
+  { id: "detective", name: "Detective", faction: "city", color: "bg-blue-600 text-white" },
+  { id: "doctor", name: "Doctor", faction: "city", color: "bg-green-600 text-white" },
+  { id: "citizen", name: "Citizen", faction: "city", color: "bg-yellow-600 text-black" },
+]
+
+const getDefaultRoles = (playerCount: number): Role[] => [
+  { ...roleTemplates[0], count: 1 },
+  { ...roleTemplates[1], count: 2 },
+  { ...roleTemplates[2], count: 1 },
+  { ...roleTemplates[3], count: 1 },
+  { ...roleTemplates[4], count: Math.max(0, playerCount - 5) },
 ]
 
 export default function LobbyPage({ params }: { params: { id: string } }) {
   const router = useRouter()
   const [players, setPlayers] = useState<Player[]>([])
   const [playerInput, setPlayerInput] = useState("")
-  const [roles, setRoles] = useState<Role[]>(defaultRoles)
+  const [roles, setRoles] = useState<Role[]>(getDefaultRoles(0))
   const [speechTimer, setSpeechTimer] = useState("60")
-  const [nightTimer, setNightTimer] = useState("30")
   const [customSpeechTimer, setCustomSpeechTimer] = useState("")
-  const [customNightTimer, setCustomNightTimer] = useState("")
   const [maxSelfHeals, setMaxSelfHeals] = useState(2)
   const [showCustomRoleModal, setShowCustomRoleModal] = useState(false)
 
@@ -58,6 +70,7 @@ export default function LobbyPage({ params }: { params: { id: string } }) {
       seatNumber: index + 1,
     }))
     setPlayers(newPlayers)
+    setRoles(getDefaultRoles(newPlayers.length))
   }
 
   const totalRoles = roles.reduce((sum, role) => sum + role.count, 0)
@@ -70,7 +83,6 @@ export default function LobbyPage({ params }: { params: { id: string } }) {
         players,
         roles,
         speechTimer: speechTimer === "custom" ? customSpeechTimer : speechTimer,
-        nightTimer: nightTimer === "custom" ? customNightTimer : nightTimer,
         maxSelfHeals,
       }
       localStorage.setItem(`game-${params.id}`, JSON.stringify(gameConfig))
@@ -191,30 +203,6 @@ export default function LobbyPage({ params }: { params: { id: string } }) {
                   )}
                 </div>
 
-                <div>
-                  <Label>Night Action Timer</Label>
-                  <Select value={nightTimer} onValueChange={setNightTimer}>
-                    <SelectTrigger className="bg-gray-700 border-gray-600">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent className="bg-gray-700 border-gray-600">
-                      <SelectItem value="30">30 seconds</SelectItem>
-                      <SelectItem value="60">60 seconds</SelectItem>
-                      <SelectItem value="90">90 seconds</SelectItem>
-                      <SelectItem value="120">120 seconds</SelectItem>
-                      <SelectItem value="custom">Custom</SelectItem>
-                    </SelectContent>
-                  </Select>
-                  {nightTimer === "custom" && (
-                    <Input
-                      type="number"
-                      placeholder="Enter seconds"
-                      value={customNightTimer}
-                      onChange={(e) => setCustomNightTimer(e.target.value)}
-                      className="mt-2 bg-gray-700 border-gray-600"
-                    />
-                  )}
-                </div>
 
                 <div>
                   <Label className="flex items-center gap-2">

--- a/components/day-phase-panel.tsx
+++ b/components/day-phase-panel.tsx
@@ -60,6 +60,9 @@ export function DayPhasePanel({
       // Execute the player
       onEliminatePlayer(playerToExecute.id)
 
+      // Give the executed player 30 seconds for last words
+      onResetTimer(30)
+
       // Reset nominations and votes for all players
       setPlayers((prev) => prev.map((p) => ({ ...p, isNominated: false, votes: 0 })))
       setVotesLocked(false)

--- a/components/game-header.tsx
+++ b/components/game-header.tsx
@@ -2,7 +2,19 @@
 
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
-import { Play, Pause, SkipBack, SkipForward, RotateCcw, Sun, Moon, Flag, Home } from "lucide-react"
+import {
+  Play,
+  Pause,
+  SkipBack,
+  SkipForward,
+  RotateCcw,
+  RotateCw,
+  Shuffle,
+  Sun,
+  Moon,
+  Flag,
+  Home,
+} from "lucide-react"
 import Link from "next/link"
 
 interface GameHeaderProps {
@@ -16,6 +28,7 @@ interface GameHeaderProps {
   onTogglePhase: () => void
   onEndGame: () => void
   onReshuffleRoles: () => void
+  onReshuffleAll: () => void
   onPreviousStep?: () => void
   onNextStep?: () => void
   currentSpeaker?: string
@@ -32,6 +45,7 @@ export function GameHeader({
   onTogglePhase,
   onEndGame,
   onReshuffleRoles,
+  onReshuffleAll,
   onPreviousStep,
   onNextStep,
   currentSpeaker,
@@ -109,8 +123,16 @@ export function GameHeader({
             </Button>
           )}
 
-          <Button size="sm" onClick={onReshuffleRoles} className="mafia-btn-secondary">
+          <Button size="sm" onClick={() => onResetTimer()} className="mafia-btn-secondary">
             <RotateCcw className="w-5 h-5" />
+          </Button>
+
+          <Button size="sm" onClick={onReshuffleRoles} className="mafia-btn-secondary">
+            <Shuffle className="w-5 h-5" />
+          </Button>
+
+          <Button size="sm" onClick={onReshuffleAll} className="mafia-btn-secondary">
+            <RotateCw className="w-5 h-5" />
           </Button>
 
           <Button size="sm" onClick={onTogglePhase} className="mafia-btn-secondary">

--- a/components/player-grid.tsx
+++ b/components/player-grid.tsx
@@ -25,9 +25,10 @@ interface PlayerGridProps {
   gamePhase: "day" | "night"
   onEliminatePlayer: (playerId: string) => void
   onRevivePlayer?: (playerId: string) => void
+  availableRoles?: { name: string; color: string; faction: string }[]
 }
 
-export function PlayerGrid({ players, setPlayers, gamePhase, onEliminatePlayer, onRevivePlayer }: PlayerGridProps) {
+export function PlayerGrid({ players, setPlayers, gamePhase, onEliminatePlayer, onRevivePlayer, availableRoles }: PlayerGridProps) {
   const [showPlayerManagement, setShowPlayerManagement] = useState(false)
 
   // Add the existing functions...
@@ -103,6 +104,7 @@ export function PlayerGrid({ players, setPlayers, gamePhase, onEliminatePlayer, 
         onClose={() => setShowPlayerManagement(false)}
         players={players}
         onUpdatePlayers={setPlayers}
+        roles={availableRoles}
       />
     </div>
   )

--- a/components/player-management-modal.tsx
+++ b/components/player-management-modal.tsx
@@ -4,6 +4,7 @@ import { useState } from "react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
 import { Trash2, Plus, Edit2, Check, X } from "lucide-react"
 
@@ -25,9 +26,10 @@ interface PlayerManagementModalProps {
   onClose: () => void
   players: GamePlayer[]
   onUpdatePlayers: (players: GamePlayer[]) => void
+  roles?: { name: string; color: string; faction: string }[]
 }
 
-export function PlayerManagementModal({ open, onClose, players, onUpdatePlayers }: PlayerManagementModalProps) {
+export function PlayerManagementModal({ open, onClose, players, onUpdatePlayers, roles = [] }: PlayerManagementModalProps) {
   const [editingId, setEditingId] = useState<string | null>(null)
   const [editName, setEditName] = useState("")
   const [newPlayerName, setNewPlayerName] = useState("")
@@ -78,6 +80,22 @@ export function PlayerManagementModal({ open, onClose, players, onUpdatePlayers 
       onUpdatePlayers([...players, newPlayer])
       setNewPlayerName("")
     }
+  }
+
+  const updateRole = (playerId: string, roleName: string) => {
+    const roleInfo = roles.find((r) => r.name === roleName)
+    onUpdatePlayers(
+      players.map((p) =>
+        p.id === playerId
+          ? {
+              ...p,
+              role: roleName,
+              roleColor: roleInfo?.color || p.roleColor,
+              faction: roleInfo?.faction || p.faction,
+            }
+          : p,
+      ),
+    )
   }
 
   return (
@@ -137,7 +155,21 @@ export function PlayerManagementModal({ open, onClose, players, onUpdatePlayers 
                 ) : (
                   <>
                     <span className="flex-1 text-sm">{player.name}</span>
-                    <div className={`px-2 py-1 rounded text-xs ${player.roleColor}`}>{player.role}</div>
+                    <Select
+                      value={player.role}
+                      onValueChange={(val) => updateRole(player.id, val)}
+                    >
+                      <SelectTrigger className="w-32 bg-gray-700 border-gray-600 text-xs">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent className="bg-gray-700 border-gray-600 text-xs">
+                        {roles.map((r) => (
+                          <SelectItem key={r.name} value={r.name}>
+                            {r.name}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
                     <Button size="sm" variant="ghost" onClick={() => startEdit(player)}>
                       <Edit2 className="w-3 h-3" />
                     </Button>

--- a/components/reshuffle-modal.tsx
+++ b/components/reshuffle-modal.tsx
@@ -8,23 +8,30 @@ interface ReshuffleModalProps {
   open: boolean
   onClose: () => void
   onConfirm: () => void
+  title?: string
+  message?: string
 }
 
-export function ReshuffleModal({ open, onClose, onConfirm }: ReshuffleModalProps) {
+export function ReshuffleModal({
+  open,
+  onClose,
+  onConfirm,
+  title = "Reshuffle Roles",
+  message = "Are you sure you want to reshuffle all player roles? This action cannot be undone and will randomly reassign roles to all players.",
+}: ReshuffleModalProps) {
   return (
     <Dialog open={open} onOpenChange={onClose}>
       <DialogContent className="bg-gray-800 border-gray-700 text-white">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <AlertTriangle className="w-5 h-5 text-yellow-400" />
-            Reshuffle Roles
+            {title}
           </DialogTitle>
         </DialogHeader>
 
         <div className="space-y-4">
           <p className="text-gray-300">
-            Are you sure you want to reshuffle all player roles? This action cannot be undone and will randomly reassign
-            roles to all players.
+            {message}
           </p>
 
           <div className="flex gap-2">


### PR DESCRIPTION
## Summary
- automatically allocate roles based on pasted players
- remove unused night timer option
- add hotkeys for moving between speakers
- provide reshuffle buttons for roles only or full restart
- allow role editing during play
- add timer reset control and post-execution timer

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f5bf935c08323ac31103b75dccd15