### PR TITLE
Improve game controls and role management

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ A modern, web-based implementation of the classic party game "Mafia" (also known
 - 👥 Support for multiple players in a single game session
 - 🎭 Role assignment for players (Mafia, Citizens, etc.)
 - ⏱️ Game timer and phase management
+- 🔀 Automatic role assignment when pasting players
+- ↩️ Keyboard hotkeys for navigating speakers
+- 💡 Tooltips and a help modal describing controls
+- 🔁 Buttons to reshuffle roles or restart the game
+- ✏️ In-game role editing for players
 - 🎨 Modern, responsive UI with dark/light theme support
 - 🔄 Real-time game state synchronization
 

--- a/app/game/[id]/lobby/page.tsx
+++ b/app/game/[id]/lobby/page.tsx
@@ -5,7 +5,13 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Textarea } from "@/components/ui/textarea"
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { PlayerList } from "@/components/player-list"
 import { RoleConfigurator } from "@/components/role-configurator"
@@ -29,23 +35,29 @@ interface Role {
   isCustom?: boolean
 }
 
-const defaultRoles: Role[] = [
-  { id: "don", name: "Don Mafia", faction: "mafia", color: "bg-black text-white", count: 1 },
-  { id: "mafia", name: "Mafia", faction: "mafia", color: "bg-red-600 text-white", count: 2 },
-  { id: "detective", name: "Detective", faction: "city", color: "bg-blue-600 text-white", count: 1 },
-  { id: "doctor", name: "Doctor", faction: "city", color: "bg-green-600 text-white", count: 1 },
-  { id: "citizen", name: "Citizen", faction: "city", color: "bg-yellow-600 text-black", count: 3 },
+const roleTemplates = [
+  { id: "don", name: "Don Mafia", faction: "mafia", color: "bg-black text-white" },
+  { id: "mafia", name: "Mafia", faction: "mafia", color: "bg-red-600 text-white" },
+  { id: "detective", name: "Detective", faction: "city", color: "bg-blue-600 text-white" },
+  { id: "doctor", name: "Doctor", faction: "city", color: "bg-green-600 text-white" },
+  { id: "citizen", name: "Citizen", faction: "city", color: "bg-yellow-600 text-black" },
+]
+
+const getDefaultRoles = (playerCount: number): Role[] => [
+  { ...roleTemplates[0], count: 1 },
+  { ...roleTemplates[1], count: 2 },
+  { ...roleTemplates[2], count: 1 },
+  { ...roleTemplates[3], count: 1 },
+  { ...roleTemplates[4], count: Math.max(0, playerCount - 5) },
 ]
 
 export default function LobbyPage({ params }: { params: { id: string } }) {
   const router = useRouter()
   const [players, setPlayers] = useState<Player[]>([])
   const [playerInput, setPlayerInput] = useState("")
-  const [roles, setRoles] = useState<Role[]>(defaultRoles)
+  const [roles, setRoles] = useState<Role[]>(getDefaultRoles(0))
   const [speechTimer, setSpeechTimer] = useState("60")
-  const [nightTimer, setNightTimer] = useState("30")
   const [customSpeechTimer, setCustomSpeechTimer] = useState("")
-  const [customNightTimer, setCustomNightTimer] = useState("")
   const [maxSelfHeals, setMaxSelfHeals] = useState(2)
   const [showCustomRoleModal, setShowCustomRoleModal] = useState(false)
 
@@ -58,6 +70,7 @@ export default function LobbyPage({ params }: { params: { id: string } }) {
       seatNumber: index + 1,
     }))
     setPlayers(newPlayers)
+    setRoles(getDefaultRoles(newPlayers.length))
   }
 
   const totalRoles = roles.reduce((sum, role) => sum + role.count, 0)
@@ -70,7 +83,6 @@ export default function LobbyPage({ params }: { params: { id: string } }) {
         players,
         roles,
         speechTimer: speechTimer === "custom" ? customSpeechTimer : speechTimer,
-        nightTimer: nightTimer === "custom" ? customNightTimer : nightTimer,
         maxSelfHeals,
       }
       localStorage.setItem(`game-${params.id}`, JSON.stringify(gameConfig))
@@ -191,30 +203,6 @@ export default function LobbyPage({ params }: { params: { id: string } }) {
                   )}
                 </div>
 
-                <div>
-                  <Label>Night Action Timer</Label>
-                  <Select value={nightTimer} onValueChange={setNightTimer}>
-                    <SelectTrigger className="bg-gray-700 border-gray-600">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent className="bg-gray-700 border-gray-600">
-                      <SelectItem value="30">30 seconds</SelectItem>
-                      <SelectItem value="60">60 seconds</SelectItem>
-                      <SelectItem value="90">90 seconds</SelectItem>
-                      <SelectItem value="120">120 seconds</SelectItem>
-                      <SelectItem value="custom">Custom</SelectItem>
-                    </SelectContent>
-                  </Select>
-                  {nightTimer === "custom" && (
-                    <Input
-                      type="number"
-                      placeholder="Enter seconds"
-                      value={customNightTimer}
-                      onChange={(e) => setCustomNightTimer(e.target.value)}
-                      className="mt-2 bg-gray-700 border-gray-600"
-                    />
-                  )}
-                </div>
 
                 <div>
                   <Label className="flex items-center gap-2">

--- a/app/game/[id]/play/page.tsx
+++ b/app/game/[id]/play/page.tsx
@@ -32,6 +32,7 @@ export default function GameDashboard({ params }: { params: { id: string } }) {
   const [nightStep, setNightStep] = useState<NightStep>("mafia-kill")
   const [showEndGameModal, setShowEndGameModal] = useState(false)
   const [showReshuffleModal, setShowReshuffleModal] = useState(false)
+  const [showReshuffleRolesModal, setShowReshuffleRolesModal] = useState(false)
   const [gameWinner, setGameWinner] = useState<"mafia" | "city" | null>(null)
 
   const [players, setPlayers] = useState<GamePlayer[]>([])
@@ -73,7 +74,7 @@ export default function GameDashboard({ params }: { params: { id: string } }) {
     }
   }, [params.id])
 
-  // Add reshuffle function
+  // Reshuffle roles only
   const reshuffleRoles = () => {
     if (!gameConfig) return
 
@@ -99,14 +100,10 @@ export default function GameDashboard({ params }: { params: { id: string } }) {
     // Shuffle roles
     const shuffledRoles = [...roleArray].sort(() => Math.random() - 0.5)
 
-    // Shuffle players (but keep their original data)
-    const shuffledPlayers = [...players].sort(() => Math.random() - 0.5)
-
-    // Assign shuffled players to seats 1, 2, 3... in order with shuffled roles
+    // Assign shuffled roles to existing players keeping their seats
     setPlayers(
-      shuffledPlayers.map((player, index) => ({
+      players.map((player, index) => ({
         ...player,
-        seatNumber: index + 1, // Seats always stay in order 1, 2, 3, 4...
         role: shuffledRoles[index],
         roleColor:
           gameConfig.roles.find((r: any) => r.name === shuffledRoles[index])?.color || "bg-gray-600 text-white",
@@ -119,6 +116,50 @@ export default function GameDashboard({ params }: { params: { id: string } }) {
     )
 
     // Reset game state
+    setGamePhase("day")
+    setDayNumber(1)
+    setNightActions({})
+  }
+
+  // Reshuffle roles and positions
+  const reshuffleAll = () => {
+    if (!gameConfig) return
+
+    const roleArray: string[] = []
+    gameConfig.roles.forEach((role: any) => {
+      for (let i = 0; i < role.count; i++) {
+        roleArray.push(role.name)
+      }
+    })
+
+    const citizenRole =
+      gameConfig.roles.find((r: any) => r.name.toLowerCase() === "citizen") ?? {
+        name: "Citizen",
+        color: "bg-yellow-600 text-black",
+        faction: "city",
+      }
+    while (players.length > roleArray.length) {
+      roleArray.push(citizenRole.name)
+    }
+
+    const shuffledRoles = [...roleArray].sort(() => Math.random() - 0.5)
+    const shuffledPlayers = [...players].sort(() => Math.random() - 0.5)
+
+    setPlayers(
+      shuffledPlayers.map((player, index) => ({
+        ...player,
+        seatNumber: index + 1,
+        role: shuffledRoles[index],
+        roleColor:
+          gameConfig.roles.find((r: any) => r.name === shuffledRoles[index])?.color || "bg-gray-600 text-white",
+        faction: gameConfig.roles.find((r: any) => r.name === shuffledRoles[index])?.faction || "city",
+        isAlive: true,
+        isNominated: false,
+        isSpeaking: false,
+        votes: 0,
+      })),
+    )
+
     setGamePhase("day")
     setDayNumber(1)
     setNightActions({})
@@ -172,6 +213,7 @@ export default function GameDashboard({ params }: { params: { id: string } }) {
     )
   }
 
+
   const moveToPreviousSpeaker = () => {
     const alivePlayers = players.filter((p) => p.isAlive)
     if (alivePlayers.length === 0) return
@@ -192,6 +234,16 @@ export default function GameDashboard({ params }: { params: { id: string } }) {
       prev.map((p, index) => (index === prevIndex ? { ...p, isSpeaking: true } : { ...p, isSpeaking: false })),
     )
   }
+
+  // Keyboard navigation for speakers
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === "ArrowRight") moveToNextSpeaker()
+      if (e.key === "ArrowLeft") moveToPreviousSpeaker()
+    }
+    window.addEventListener("keydown", handleKey)
+    return () => window.removeEventListener("keydown", handleKey)
+  }, [moveToNextSpeaker, moveToPreviousSpeaker])
 
   const togglePhase = () => {
     if (gamePhase === "day") {
@@ -260,7 +312,8 @@ export default function GameDashboard({ params }: { params: { id: string } }) {
         onResetTimer={resetTimer}
         onTogglePhase={togglePhase}
         onEndGame={() => setShowEndGameModal(true)}
-        onReshuffleRoles={() => setShowReshuffleModal(true)}
+        onReshuffleRoles={() => setShowReshuffleRolesModal(true)}
+        onReshuffleAll={() => setShowReshuffleModal(true)}
         onPreviousStep={moveToPreviousSpeaker}
         onNextStep={moveToNextSpeaker}
         currentSpeaker={players.find((p) => p.isSpeaking)?.name}
@@ -276,6 +329,7 @@ export default function GameDashboard({ params }: { params: { id: string } }) {
               gamePhase={gamePhase}
               onEliminatePlayer={eliminatePlayer}
               onRevivePlayer={revivePlayer}
+              availableRoles={gameConfig?.roles}
             />
           </div>
 
@@ -313,12 +367,25 @@ export default function GameDashboard({ params }: { params: { id: string } }) {
       />
 
       <ReshuffleModal
+        open={showReshuffleRolesModal}
+        onClose={() => setShowReshuffleRolesModal(false)}
+        onConfirm={() => {
+          reshuffleRoles()
+          setShowReshuffleRolesModal(false)
+        }}
+        title="Reshuffle Roles"
+        message="All players will keep their seats but receive new roles."
+      />
+
+      <ReshuffleModal
         open={showReshuffleModal}
         onClose={() => setShowReshuffleModal(false)}
         onConfirm={() => {
-          reshuffleRoles()
+          reshuffleAll()
           setShowReshuffleModal(false)
         }}
+        title="Restart & Reshuffle"
+        message="Players will be reseated and assigned new roles."
       />
     </div>
   )

--- a/components/day-phase-panel.tsx
+++ b/components/day-phase-panel.tsx
@@ -60,6 +60,9 @@ export function DayPhasePanel({
       // Execute the player
       onEliminatePlayer(playerToExecute.id)
 
+      // Give the executed player 30 seconds for last words
+      onResetTimer(30)
+
       // Reset nominations and votes for all players
       setPlayers((prev) => prev.map((p) => ({ ...p, isNominated: false, votes: 0 })))
       setVotesLocked(false)

--- a/components/game-header.tsx
+++ b/components/game-header.tsx
@@ -1,9 +1,30 @@
 "use client"
 
+import { useState } from "react"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
-import { Play, Pause, SkipBack, SkipForward, RotateCcw, Sun, Moon, Flag, Home } from "lucide-react"
+import {
+  Play,
+  Pause,
+  SkipBack,
+  SkipForward,
+  RotateCcw,
+  RotateCw,
+  Shuffle,
+  Info,
+  Sun,
+  Moon,
+  Flag,
+  Home,
+} from "lucide-react"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
 import Link from "next/link"
+import { InfoModal } from "./info-modal"
 
 interface GameHeaderProps {
   gameId: string
@@ -16,6 +37,7 @@ interface GameHeaderProps {
   onTogglePhase: () => void
   onEndGame: () => void
   onReshuffleRoles: () => void
+  onReshuffleAll: () => void
   onPreviousStep?: () => void
   onNextStep?: () => void
   currentSpeaker?: string
@@ -32,10 +54,12 @@ export function GameHeader({
   onTogglePhase,
   onEndGame,
   onReshuffleRoles,
+  onReshuffleAll,
   onPreviousStep,
   onNextStep,
   currentSpeaker,
 }: GameHeaderProps) {
+  const [showInfo, setShowInfo] = useState(false)
   const formatTime = (seconds: number) => {
     const mins = Math.floor(seconds / 60)
     const secs = seconds % 60
@@ -53,8 +77,9 @@ export function GameHeader({
   }
 
   return (
-    <div className="sticky top-0 z-50 mafia-header">
-      <div className="container mx-auto flex items-center justify-between px-4 py-4">
+    <TooltipProvider delayDuration={0}>
+      <div className="sticky top-0 z-50 mafia-header">
+        <div className="container mx-auto flex items-center justify-between px-4 py-4">
         {/* Phase Label & Game Info */}
         <div className="flex items-center gap-6">
           <Link href="/" className="text-gray-400 hover:text-yellow-600 transition-colors">
@@ -89,39 +114,98 @@ export function GameHeader({
 
         {/* Controls */}
         <div className="flex items-center gap-3">
-          <Button
-            size="sm"
-            onClick={onToggleTimer}
-            className={isTimerRunning ? "mafia-btn-primary" : "mafia-btn-secondary"}
-          >
-            {isTimerRunning ? <Pause className="w-5 h-5" /> : <Play className="w-5 h-5" />}
-          </Button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                size="sm"
+                onClick={onToggleTimer}
+                className={isTimerRunning ? "mafia-btn-primary" : "mafia-btn-secondary"}
+              >
+                {isTimerRunning ? <Pause className="w-5 h-5" /> : <Play className="w-5 h-5" />}
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">Play/Pause Timer</TooltipContent>
+          </Tooltip>
 
           {onPreviousStep && (
-            <Button size="sm" onClick={onPreviousStep} className="mafia-btn-secondary">
-              <SkipBack className="w-5 h-5" />
-            </Button>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button size="sm" onClick={onPreviousStep} className="mafia-btn-secondary">
+                  <SkipBack className="w-5 h-5" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">Previous Speaker</TooltipContent>
+            </Tooltip>
           )}
 
           {onNextStep && (
-            <Button size="sm" onClick={onNextStep} className="mafia-btn-secondary">
-              <SkipForward className="w-5 h-5" />
-            </Button>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button size="sm" onClick={onNextStep} className="mafia-btn-secondary">
+                  <SkipForward className="w-5 h-5" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">Next Speaker</TooltipContent>
+            </Tooltip>
           )}
 
-          <Button size="sm" onClick={onReshuffleRoles} className="mafia-btn-secondary">
-            <RotateCcw className="w-5 h-5" />
-          </Button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button size="sm" onClick={() => onResetTimer()} className="mafia-btn-secondary">
+                <RotateCcw className="w-5 h-5" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">Reset Timer</TooltipContent>
+          </Tooltip>
 
-          <Button size="sm" onClick={onTogglePhase} className="mafia-btn-secondary">
-            {gamePhase === "day" ? <Moon className="w-5 h-5" /> : <Sun className="w-5 h-5" />}
-          </Button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button size="sm" onClick={onReshuffleRoles} className="mafia-btn-secondary">
+                <Shuffle className="w-5 h-5" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">Reshuffle Roles</TooltipContent>
+          </Tooltip>
 
-          <Button size="sm" onClick={onEndGame} className="bg-red-800 hover:bg-red-700 text-white">
-            <Flag className="w-5 h-5" />
-          </Button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button size="sm" onClick={onReshuffleAll} className="mafia-btn-secondary">
+                <RotateCw className="w-5 h-5" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">Restart &amp; Reshuffle</TooltipContent>
+          </Tooltip>
+
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button size="sm" onClick={onTogglePhase} className="mafia-btn-secondary">
+                {gamePhase === "day" ? <Moon className="w-5 h-5" /> : <Sun className="w-5 h-5" />}
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">Toggle Phase</TooltipContent>
+          </Tooltip>
+
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button size="sm" onClick={onEndGame} className="bg-red-800 hover:bg-red-700 text-white">
+                <Flag className="w-5 h-5" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">End Game</TooltipContent>
+          </Tooltip>
+
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button size="sm" onClick={() => setShowInfo(true)} className="mafia-btn-secondary">
+                <Info className="w-5 h-5" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">How to Use</TooltipContent>
+          </Tooltip>
         </div>
       </div>
     </div>
+    <InfoModal open={showInfo} onClose={() => setShowInfo(false)} />
+  </TooltipProvider>
   )
 }

--- a/components/info-modal.tsx
+++ b/components/info-modal.tsx
@@ -1,0 +1,36 @@
+"use client"
+
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+import { Info } from "lucide-react"
+
+interface InfoModalProps {
+  open: boolean
+  onClose: () => void
+}
+
+export function InfoModal({ open, onClose }: InfoModalProps) {
+  return (
+    <Dialog open={open} onOpenChange={onClose}>
+      <DialogContent className="bg-gray-800 border-gray-700 text-white max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Info className="w-5 h-5" />
+            How to Use
+          </DialogTitle>
+        </DialogHeader>
+        <div className="space-y-3 text-sm">
+          <p>Use the controls in the header to manage the game timer and phases.</p>
+          <ul className="list-disc list-inside space-y-1">
+            <li>Play/Pause toggles the timer.</li>
+            <li>Skip icons or ←/→ keys change the current speaker.</li>
+            <li>Rotate arrow resets the timer.</li>
+            <li>Shuffle reshuffles roles for all players.</li>
+            <li>Rotate clockwise restarts the game and reshuffles positions.</li>
+            <li>Moon/Sun toggles between day and night.</li>
+            <li>Flag ends the game.</li>
+          </ul>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/player-grid.tsx
+++ b/components/player-grid.tsx
@@ -31,7 +31,6 @@ interface PlayerGridProps {
 export function PlayerGrid({ players, setPlayers, gamePhase, onEliminatePlayer, onRevivePlayer, availableRoles }: PlayerGridProps) {
   const [showPlayerManagement, setShowPlayerManagement] = useState(false)
 
-  // Add the existing functions...
   const togglePlayerStatus = (playerId: string, status: "nominated" | "speaking") => {
     setPlayers(
       players.map((p) => {

--- a/components/player-grid.tsx
+++ b/components/player-grid.tsx
@@ -25,9 +25,10 @@ interface PlayerGridProps {
   gamePhase: "day" | "night"
   onEliminatePlayer: (playerId: string) => void
   onRevivePlayer?: (playerId: string) => void
+  availableRoles?: { name: string; color: string; faction: string }[]
 }
 
-export function PlayerGrid({ players, setPlayers, gamePhase, onEliminatePlayer, onRevivePlayer }: PlayerGridProps) {
+export function PlayerGrid({ players, setPlayers, gamePhase, onEliminatePlayer, onRevivePlayer, availableRoles }: PlayerGridProps) {
   const [showPlayerManagement, setShowPlayerManagement] = useState(false)
 
   // Add the existing functions...
@@ -103,6 +104,7 @@ export function PlayerGrid({ players, setPlayers, gamePhase, onEliminatePlayer, 
         onClose={() => setShowPlayerManagement(false)}
         players={players}
         onUpdatePlayers={setPlayers}
+        roles={availableRoles}
       />
     </div>
   )

--- a/components/player-management-modal.tsx
+++ b/components/player-management-modal.tsx
@@ -4,6 +4,7 @@ import { useState } from "react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
 import { Trash2, Plus, Edit2, Check, X } from "lucide-react"
 
@@ -25,9 +26,10 @@ interface PlayerManagementModalProps {
   onClose: () => void
   players: GamePlayer[]
   onUpdatePlayers: (players: GamePlayer[]) => void
+  roles?: { name: string; color: string; faction: string }[]
 }
 
-export function PlayerManagementModal({ open, onClose, players, onUpdatePlayers }: PlayerManagementModalProps) {
+export function PlayerManagementModal({ open, onClose, players, onUpdatePlayers, roles = [] }: PlayerManagementModalProps) {
   const [editingId, setEditingId] = useState<string | null>(null)
   const [editName, setEditName] = useState("")
   const [newPlayerName, setNewPlayerName] = useState("")
@@ -78,6 +80,22 @@ export function PlayerManagementModal({ open, onClose, players, onUpdatePlayers 
       onUpdatePlayers([...players, newPlayer])
       setNewPlayerName("")
     }
+  }
+
+  const updateRole = (playerId: string, roleName: string) => {
+    const roleInfo = roles.find((r) => r.name === roleName)
+    onUpdatePlayers(
+      players.map((p) =>
+        p.id === playerId
+          ? {
+              ...p,
+              role: roleName,
+              roleColor: roleInfo?.color || p.roleColor,
+              faction: roleInfo?.faction || p.faction,
+            }
+          : p,
+      ),
+    )
   }
 
   return (
@@ -137,7 +155,21 @@ export function PlayerManagementModal({ open, onClose, players, onUpdatePlayers 
                 ) : (
                   <>
                     <span className="flex-1 text-sm">{player.name}</span>
-                    <div className={`px-2 py-1 rounded text-xs ${player.roleColor}`}>{player.role}</div>
+                    <Select
+                      value={player.role}
+                      onValueChange={(val) => updateRole(player.id, val)}
+                    >
+                      <SelectTrigger className="w-32 bg-gray-700 border-gray-600 text-xs">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent className="bg-gray-700 border-gray-600 text-xs">
+                        {roles.map((r) => (
+                          <SelectItem key={r.name} value={r.name}>
+                            {r.name}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
                     <Button size="sm" variant="ghost" onClick={() => startEdit(player)}>
                       <Edit2 className="w-3 h-3" />
                     </Button>

--- a/components/reshuffle-modal.tsx
+++ b/components/reshuffle-modal.tsx
@@ -8,23 +8,30 @@ interface ReshuffleModalProps {
   open: boolean
   onClose: () => void
   onConfirm: () => void
+  title?: string
+  message?: string
 }
 
-export function ReshuffleModal({ open, onClose, onConfirm }: ReshuffleModalProps) {
+export function ReshuffleModal({
+  open,
+  onClose,
+  onConfirm,
+  title = "Reshuffle Roles",
+  message = "Are you sure you want to reshuffle all player roles? This action cannot be undone and will randomly reassign roles to all players.",
+}: ReshuffleModalProps) {
   return (
     <Dialog open={open} onOpenChange={onClose}>
       <DialogContent className="bg-gray-800 border-gray-700 text-white">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <AlertTriangle className="w-5 h-5 text-yellow-400" />
-            Reshuffle Roles
+            {title}
           </DialogTitle>
         </DialogHeader>
 
         <div className="space-y-4">
           <p className="text-gray-300">
-            Are you sure you want to reshuffle all player roles? This action cannot be undone and will randomly reassign
-            roles to all players.
+            {message}
           </p>
 
           <div className="flex gap-2">


### PR DESCRIPTION
## Summary
- automatically allocate roles based on pasted players
- remove unused night timer option
- add hotkeys for moving between speakers
- provide reshuffle buttons for roles only or full restart
- allow role editing during play
- add timer reset control and post-execution timer
- show help modal and tooltips for header controls

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f5bf935c08323ac31103b75dccd15